### PR TITLE
Adding support for validatorUrl option for swagger

### DIFF
--- a/config/swagger-lume.php
+++ b/config/swagger-lume.php
@@ -117,6 +117,16 @@ return [
      */
     'proxy' => false,
 
+    /*
+     |--------------------------------------------------------------------------
+     | Uncomment to pass the validatorUrl parameter to SwaggerUi init on the JS
+     | side.  A null value here disables validation.  A string will override
+     | the default url.  If not specified, behavior is default and validation
+     | is enabled.
+     |--------------------------------------------------------------------------
+     */
+    // 'validatorUrl' => null,
+
     'headers' => [
         /*
         |--------------------------------------------------------------------------

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -45,6 +45,10 @@
     window.swaggerUi = new SwaggerUi({
         url: url,
         dom_id: "swagger-ui-container",
+        @if(array_key_exists('validatorUrl', get_defined_vars()))
+        // This differentiates between a null value and an undefined variable
+        validatorUrl: {!! isset($validatorUrl) ? '"' . $validatorUrl . '"' : 'null' !!},
+        @endif
         supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
         onComplete: function(swaggerApi, swaggerUi){
             @if(isset($requestHeaders))

--- a/src/routes.php
+++ b/src/routes.php
@@ -52,7 +52,7 @@ $app->get(config('swagger-lume.routes.api'), function () {
             'secure' => (new Request)->secure(),
             'urlToDocs' => url(config('swagger-lume.routes.docs')),
             'requestHeaders' => config('swagger-lume.headers.request'),
-        ],$extras),
+        ], $extras),
         200
     );
 

--- a/src/routes.php
+++ b/src/routes.php
@@ -34,6 +34,15 @@ $app->get(config('swagger-lume.routes.api'), function () {
         (new Request)->setTrustedProxies([$proxy]);
     }
 
+    $extras = [];
+    $conf = config('swagger-lume');
+    if (array_key_exists('validatorUrl', $conf)) {
+        // This allows for a null value, since this has potentially
+        // desirable side effects for swagger.  See the view for more
+        // details.
+        $extras['validatorUrl'] = $conf['validatorUrl'];
+    }
+
     //need the / at the end to avoid CORS errors on Homestead systems.
     $response = new Response(
         view('swagger-lume::index', [
@@ -43,7 +52,7 @@ $app->get(config('swagger-lume.routes.api'), function () {
             'secure' => (new Request)->secure(),
             'urlToDocs' => url(config('swagger-lume.routes.docs')),
             'requestHeaders' => config('swagger-lume.headers.request'),
-        ]),
+        ],$extras),
         200
     );
 


### PR DESCRIPTION
This adds support for the validatorUrl option to the SwaggerUi object for swagger.

See [here](https://github.com/swagger-api/swagger-ui/issues/630) and [here](https://github.com/swagger-api/swagger-ui#parameters) for details, but basically this allows you to either specify a custom url for validation or to disable it by setting it to null.  If the array key is omitted from the lumen swagger config, previous behavior is maintained.  If you specify validatorUrl in the config and set it to null, it disables the validator.  If you set it to a string, it passes on this custom url to swagger for validation.