### PR TITLE
changes to support lumen 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
 matrix:
   fast_finish: true
   include:
-  - php: 5.6
   - php: 7.0
   - php: 7.1
     env: REPORT_TESTS_COVERAGE=1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/DarkaOnLine/SwaggerLume.svg?branch=master)](https://travis-ci.org/DarkaOnLine/SwaggerLume)
+[![Build Status](https://travis-ci.org/jellevl/SwaggerLume.svg?branch=master)](https://travis-ci.org/jellevl/SwaggerLume)
 [![Coverage Status](https://coveralls.io/repos/github/DarkaOnLine/SwaggerLume/badge.svg?branch=master)](https://coveralls.io/github/DarkaOnLine/SwaggerLume?branch=master)
 [![Code Climate](https://codeclimate.com/repos/56a70d5ba9ee680070010a05/badges/40dbc66effc417734313/gpa.svg)](https://codeclimate.com/repos/56a70d5ba9ee680070010a05/feed)
 [![StyleCI](https://styleci.io/repos/50113229/shield)](https://styleci.io/repos/50113229)

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {    
     "php": ">=5.6.4",
-    "laravel/lumen-framework": "~5.4",
+    "laravel/lumen-framework": "~5.5",
     "zircote/swagger-php": "~2.0",
     "swagger-api/swagger-ui": "^3.0"
   },

--- a/src/Console/GenerateDocsCommand.php
+++ b/src/Console/GenerateDocsCommand.php
@@ -26,7 +26,7 @@ class GenerateDocsCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->info('Regenerating docs');
         Generator::generateDocs();

--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -25,7 +25,7 @@ class PublishCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->info('Publishing all files');
         $this->call('swagger-lume:publish-config');

--- a/src/Console/PublishConfigCommand.php
+++ b/src/Console/PublishConfigCommand.php
@@ -26,7 +26,7 @@ class PublishConfigCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->info('Publish config files');
 

--- a/src/Console/PublishViewsCommand.php
+++ b/src/Console/PublishViewsCommand.php
@@ -26,7 +26,7 @@ class PublishViewsCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->info('Publishing view files');
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -27,7 +27,7 @@ class ServiceProvider extends BaseProvider
         $viewPath = __DIR__.'/../resources/views';
         $this->loadViewsFrom($viewPath, 'swagger-lume');
 
-        $this->app->group(['namespace' => 'SwaggerLume'], function ($route) {
+        $this->app->router->group(['namespace' => 'SwaggerLume'], function ($route) {
             require __DIR__.'/routes.php';
         });
     }

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -36,5 +36,6 @@ class CommandsTest extends LumenTestCase
     {
         $this->setPaths();
         Artisan::call('swagger-lume:publish');
+        $this->assertTrue(true);
     }
 }

--- a/tests/LumenTestCase.php
+++ b/tests/LumenTestCase.php
@@ -53,7 +53,7 @@ class LumenTestCase extends TestCase
 
         $app->register(SwaggerLumeServiceProvider::class);
 
-        $app->group(['namespace' => 'SwaggerLume'], function ($route) {
+        $app->router->group(['namespace' => 'SwaggerLume'], function ($route) {
             require __DIR__.'/../src/routes.php';
         });
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,25 @@
+<?php
+/*
+|--------------------------------------------------------------------------
+| Register The Composer Auto Loader
+|--------------------------------------------------------------------------
+|
+| Composer provides a convenient, automatically generated class loader
+| for our application. We just need to utilize it! We'll require it
+| into the script here so that we do not have to worry about the
+| loading of any our classes "manually". Feels great to relax.
+|
+*/
+require __DIR__.'/../vendor/autoload.php';
+/*
+|--------------------------------------------------------------------------
+| Set The Default Timezone
+|--------------------------------------------------------------------------
+|
+| Here we will set the default timezone for PHP. PHP is notoriously mean
+| if the timezone is not explicitly set. This will be used by each of
+| the PHP date and date-time functions throughout the application.
+|
+*/
+date_default_timezone_set('UTC');
+Carbon\Carbon::setTestNow(Carbon\Carbon::now());


### PR DESCRIPTION
To make SwaggerLume compatible with Lumen 5.5. the artisan commands had to be updated.
function Fire() is changed to handle().
