### PR TITLE
Set correct docs json file response header

### DIFF
--- a/src/Http/Controllers/SwaggerLumeController.php
+++ b/src/Http/Controllers/SwaggerLumeController.php
@@ -4,7 +4,6 @@ namespace SwaggerLume\Http\Controllers;
 
 use SwaggerLume\Generator;
 use Illuminate\Http\Response;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Request;
 use Laravel\Lumen\Routing\Controller as BaseController;
@@ -16,7 +15,7 @@ class SwaggerLumeController extends BaseController
      *
      * @param null $jsonFile
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return \Illuminate\Http\Response
      */
     public function docs($jsonFile = null)
     {
@@ -29,7 +28,7 @@ class SwaggerLumeController extends BaseController
 
         $content = File::get($filePath);
 
-        return new JsonResponse($content);
+        return new Response($content, 200, ['Content-Type' => 'application/json']);
     }
 
     /**

--- a/src/Http/Controllers/SwaggerLumeController.php
+++ b/src/Http/Controllers/SwaggerLumeController.php
@@ -28,7 +28,7 @@ class SwaggerLumeController extends BaseController
 
         $content = File::get($filePath);
 
-        return new Response($content, 200);
+        return new Response($content, 200, ['Content-Type' => 'application/json']);
     }
 
     /**

--- a/src/Http/Controllers/SwaggerLumeController.php
+++ b/src/Http/Controllers/SwaggerLumeController.php
@@ -4,6 +4,7 @@ namespace SwaggerLume\Http\Controllers;
 
 use SwaggerLume\Generator;
 use Illuminate\Http\Response;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Request;
 use Laravel\Lumen\Routing\Controller as BaseController;
@@ -15,7 +16,7 @@ class SwaggerLumeController extends BaseController
      *
      * @param null $jsonFile
      *
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\JsonResponse
      */
     public function docs($jsonFile = null)
     {
@@ -28,7 +29,7 @@ class SwaggerLumeController extends BaseController
 
         $content = File::get($filePath);
 
-        return new Response($content, 200, ['Content-Type' => 'application/json']);
+        return new JsonResponse($content);
     }
 
     /**


### PR DESCRIPTION
This fixes the docs page to behave like a html page and use the correct content-type header.

Swagger itself does this too: http://petstore.swagger.io/v2/swagger.json