### PR TITLE
Update generator.php to properly support OpenAPI

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -20,7 +20,12 @@ class Generator
 
             File::makeDirectory($docDir);
             $excludeDirs = config('swagger-lume.paths.excludes');
-            $swagger = \Swagger\scan($appDir, ['exclude' => $excludeDirs]);
+            
+            if (config('swagger-lume.swagger_version') === '3.0') {
+                $swagger = \OpenApi\scan($appDir, ['exclude' => $excludeDirs]);
+            } else {
+                $swagger = \Swagger\scan($appDir, ['exclude' => $excludeDirs]);
+            }
 
             if (config('swagger-lume.paths.base') !== null) {
                 $swagger->basePath = config('swagger-lume.paths.base');

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -20,8 +20,8 @@ class Generator
 
             File::makeDirectory($docDir);
             $excludeDirs = config('swagger-lume.paths.excludes');
-            
-            if (config('swagger-lume.swagger_version') === '3.0') {
+
+            if (version_compare(config('swagger-lume.swagger_version'), '3.0', '>=')) {
                 $swagger = \OpenApi\scan($appDir, ['exclude' => $excludeDirs]);
             } else {
                 $swagger = \Swagger\scan($appDir, ['exclude' => $excludeDirs]);

--- a/tests/storage/annotations/OpenApi/Anotations.php
+++ b/tests/storage/annotations/OpenApi/Anotations.php
@@ -1,14 +1,14 @@
 <?php
 
 /**
- * @OAS\Info(
+ * @OA\Info(
  *      version="1.0.0",
  *      title="SwaggerLume OpenApi",
  *      description="SwaggerLume OpenApi description",
- *      @OAS\Contact(
+ *      @OA\Contact(
  *          email="darius@matulionis.lt"
  *      ),
- *     @OAS\License(
+ *     @OA\License(
  *         name="Apache 2.0",
  *         url="http://www.apache.org/licenses/LICENSE-2.0.html"
  *     )
@@ -16,26 +16,26 @@
  */
 
 /**
- *  @OAS\Server(
+ *  @OA\Server(
  *      url=SWAGGER_LUME_CONST_HOST,
  *      description="SwaggerLume OpenApi dynamic host server"
  *  )
  *
- *  @OAS\Server(
+ *  @OA\Server(
 *      url="https://projects.dev/api/v1",
  *      description="SwaggerLume OpenApi Server"
  * )
  */
 
 /**
- * @OAS\SecurityScheme(
+ * @OA\SecurityScheme(
  *     type="oauth2",
  *     description="Use a global client_id / client_secret and your username / password combo to obtain a token",
  *     name="Password Based",
  *     in="header",
  *     scheme="https",
  *     securityScheme="Password Based",
- *     @OAS\Flow(
+ *     @OA\Flow(
  *         flow="password",
  *         authorizationUrl="/oauth/authorize",
  *         tokenUrl="/oauth/token",
@@ -45,41 +45,41 @@
  */
 
 /**
- * @OAS\Tag(
+ * @OA\Tag(
  *     name="project",
  *     description="Everything about your Projects",
- *     @OAS\ExternalDocumentation(
+ *     @OA\ExternalDocumentation(
  *         description="Find out more",
  *         url="http://swagger.io"
  *     )
  * )
  *
- * @OAS\Tag(
+ * @OA\Tag(
  *     name="user",
  *     description="Operations about user",
- *     @OAS\ExternalDocumentation(
+ *     @OA\ExternalDocumentation(
  *         description="Find out more about",
  *         url="http://swagger.io"
  *     )
  * )
- * @OAS\ExternalDocumentation(
+ * @OA\ExternalDocumentation(
  *     description="Find out more about Swagger",
  *     url="http://swagger.io"
  * )
  */
 
 /**
- * @OAS\Get(
+ * @OA\Get(
  *      path="/projects",
  *      operationId="getProjectsList",
  *      tags={"Projects"},
  *      summary="Get list of projects",
  *      description="Returns list of projects",
- *      @OAS\Response(
+ *      @OA\Response(
  *          response=200,
  *          description="successful operation"
  *       ),
- *       @OAS\Response(response=400, description="Bad request"),
+ *       @OA\Response(response=400, description="Bad request"),
  *       security={
  *           {"api_key_security_example": {}}
  *       }
@@ -89,27 +89,27 @@
  */
 
 /**
- * @OAS\Get(
+ * @OA\Get(
  *      path="/projects/{id}",
  *      operationId="getProjectById",
  *      tags={"Projects"},
  *      summary="Get project information",
  *      description="Returns project data",
- *      @OAS\Parameter(
+ *      @OA\Parameter(
  *          name="id",
  *          description="Project id",
  *          required=true,
  *          in="path",
- *          @OAS\Schema(
+ *          @OA\Schema(
  *              type="integer"
  *          )
  *      ),
- *      @OAS\Response(
+ *      @OA\Response(
  *          response=200,
  *          description="successful operation"
  *       ),
- *      @OAS\Response(response=400, description="Bad request"),
- *      @OAS\Response(response=404, description="Resource Not Found"),
+ *      @OA\Response(response=400, description="Bad request"),
+ *      @OA\Response(response=404, description="Resource Not Found"),
  *      security={
  *         {
  *             "oauth2_security_example": {"write:projects", "read:projects"}


### PR DESCRIPTION
When following the `README.md` about using the OpenAPI specification users will eventually run into an issue where the Generator is trying to call an undefined function.

```
Regenerating docs

In Generator.php line 27:

  Call to undefined function Swagger\scan()
```

This PR solves the issue by checking if OpenAPI is enabled, and then calling the correct function