### PR TITLE
Fix the url docs link and handling referenced json files

### DIFF
--- a/src/Http/Controllers/SwaggerLumeController.php
+++ b/src/Http/Controllers/SwaggerLumeController.php
@@ -46,7 +46,7 @@ class SwaggerLumeController extends BaseController
         $response = new Response(
             view('swagger-lume::index', [
                 'secure' => Request::secure(),
-                'urlToDocs' => route('swagger-lume.docs') . '/' . config('swagger-lume.paths.docs_json'),
+                'urlToDocs' => route('swagger-lume.docs', ['jsonFile' => config('swagger-lume.paths.docs_json')]),
                 'operationsSorter' => config('swagger-lume.operations_sort'),
                 'configUrl' => config('swagger-lume.additional_config_url'),
                 'validatorUrl' => config('swagger-lume.validator_url'),

--- a/src/Http/Controllers/SwaggerLumeController.php
+++ b/src/Http/Controllers/SwaggerLumeController.php
@@ -46,7 +46,7 @@ class SwaggerLumeController extends BaseController
         $response = new Response(
             view('swagger-lume::index', [
                 'secure' => Request::secure(),
-                'urlToDocs' => route('swagger-lume.docs'),
+                'urlToDocs' => route('swagger-lume.docs') . '/' . config('swagger-lume.paths.docs_json'),
                 'operationsSorter' => config('swagger-lume.operations_sort'),
                 'configUrl' => config('swagger-lume.additional_config_url'),
                 'validatorUrl' => config('swagger-lume.validator_url'),

--- a/src/routes.php
+++ b/src/routes.php
@@ -1,6 +1,6 @@
 <?php
 
-$route->get(config('swagger-lume.routes.docs'), [
+$route->get(config('swagger-lume.routes.docs').'/{jsonFile:(?!asset).*}', [
     'as' => 'swagger-lume.docs',
     'middleware' => config('swagger-lume.routes.middleware.docs', []),
     'uses' => 'Http\Controllers\SwaggerLumeController@docs',


### PR DESCRIPTION
In an application I'm using references to json files in my swagger documentation (these files are also used for validation of requests and responses, as well as tests, that why I want to use these references and don't put them inline).
In the laravel-package this works correctly, but the lumen-package didn't use the file name in the docs correctly, and referenced files were also not served through the `SwaggerLumeController`.

I applied changes that give the expected result. I.e. the default docs url is now `.../docs/api-docs.json` (in comparison to `../docs/` it was before, and json files referenced in api-docs.json are served correctly.

Let me know if anything is unclear.