### PR TITLE
Adding import OpenApi\Annotations tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ Swagger-php
 ======================
 The actual Swagger spec is beyond the scope of this package. All SwaggerLume does is package up swagger-php and swagger-ui in a Laravel-friendly fashion, and tries to make it easy to serve. For info on how to use swagger-php [look here](http://zircote.com/swagger-php/). For good examples of swagger-php in action [look here](https://github.com/zircote/swagger-php/tree/master/Examples/petstore.swagger.io).
 
+**Important:** Make sure that you add the include statement on all pages with annotations!
+
+```
+use OpenApi\Annotations as OA;
+```
+
 ## Support on Beerpay
 Hey dude! Help me out for a couple of :beers:!
 


### PR DESCRIPTION
As a newbie to getting this running, I referred to this article https://medium.com/@tatianaensslin/how-to-add-swagger-ui-to-php-server-code-f1610c01dc03 which gave some very useful and more complete setup steps.

One important step was importing the Annotations.

This is a minor readme change to support this.