### PR TITLE
Support multiple scan directories. Closes #105.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": ">=7.2",
     "laravel/lumen-framework": "~6.0|~7.0|^8.0",
-    "zircote/swagger-php": "~2.0|3.*",
+    "zircote/swagger-php": "~2.0|3.*|4.*",
     "swagger-api/swagger-ui": "^3.0"
   },
   "require-dev": {

--- a/config/swagger-lume.php
+++ b/config/swagger-lume.php
@@ -69,10 +69,12 @@ return [
 
         /*
         |--------------------------------------------------------------------------
-        | Absolute path to directory containing the swagger annotations are stored.
+        | Absolute paths to directories where the swagger annotations are stored.
+        | For Swagger versions < 3.0, only one directory is supported, and only the
+        | first item of the array will be considered.
         |--------------------------------------------------------------------------
          */
-        'annotations' => base_path('app'),
+        'annotations' => [base_path('app')],
 
         /*
         |--------------------------------------------------------------------------

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -8,9 +8,9 @@ class Generator
 {
     public static function generateDocs()
     {
-        $appDir = config('swagger-lume.paths.annotations');
+        $appDirs = config('swagger-lume.paths.annotations');
         $docDir = config('swagger-lume.paths.docs');
-        if (! File::exists($docDir) || is_writable($docDir)) {
+        if (!File::exists($docDir) || is_writable($docDir)) {
             // delete all existing documentation
             if (File::exists($docDir)) {
                 File::deleteDirectory($docDir);
@@ -22,9 +22,13 @@ class Generator
             $excludeDirs = config('swagger-lume.paths.excludes');
 
             if (version_compare(config('swagger-lume.swagger_version'), '3.0', '>=')) {
-                $swagger = \OpenApi\scan($appDir, ['exclude' => $excludeDirs]);
+                $appDirsWithExclude = array_map(function ($path) use ($excludeDirs) {
+                    return \OpenApi\Util::finder($path, $excludeDirs);
+                }, $appDirs);
+
+                $swagger = \OpenApi\Generator::scan($appDirsWithExclude);
             } else {
-                $swagger = \Swagger\scan($appDir, ['exclude' => $excludeDirs]);
+                $swagger = \Swagger\scan($appDirs[0], ['exclude' => $excludeDirs]);
             }
 
             if (config('swagger-lume.paths.base') !== null) {
@@ -41,7 +45,7 @@ class Generator
 
     protected static function defineConstants(array $constants)
     {
-        if (! empty($constants)) {
+        if (!empty($constants)) {
             foreach ($constants as $key => $value) {
                 defined($key) || define($key, $value);
             }


### PR DESCRIPTION
Related issues: 
* https://github.com/DarkaOnLine/SwaggerLume/issues/105
*  DarkaOnLine/L5-Swagger#63

The purpose of this PR is to make the `annotations` configuration support arrays, so multiple scan directories could be used. 

It also updates the scanning method to reflect his; also, the current implementation is using a deprecated function, and this PR fixes that.