### PR TITLE
Trigger generation of api docs json when fetching only json

### DIFF
--- a/src/Http/Controllers/SwaggerLumeController.php
+++ b/src/Http/Controllers/SwaggerLumeController.php
@@ -22,7 +22,20 @@ class SwaggerLumeController extends BaseController
             (! is_null($jsonFile) ? $jsonFile : config('swagger-lume.paths.docs_json'));
         
         if (config('swagger-lume.generate_always') && ! File::exists($filePath)) {
-            Generator::generateDocs();
+           try {               
+                Generator::generateDocs();
+            } catch (\Exception $e) {
+                Log::error($e);
+
+                abort(
+                    404,
+                    sprintf(
+                        'Unable to generate documentation file to: "%s". Please make sure directory is writable. Error: %s',
+                        $filePath,
+                        $e->getMessage()
+                    )
+                );
+            }
         }
         
         if (! File::exists($filePath)) {

--- a/src/Http/Controllers/SwaggerLumeController.php
+++ b/src/Http/Controllers/SwaggerLumeController.php
@@ -20,7 +20,11 @@ class SwaggerLumeController extends BaseController
     {
         $filePath = config('swagger-lume.paths.docs').'/'.
             (! is_null($jsonFile) ? $jsonFile : config('swagger-lume.paths.docs_json'));
-
+        
+        if (config('swagger-lume.generate_always') && ! File::exists($filePath)) {
+            Generator::generateDocs();
+        }
+        
         if (! File::exists($filePath)) {
             abort(404, 'Cannot find '.$filePath);
         }


### PR DESCRIPTION
When using the generate_always setting in a production environment with multiple servers, generation of the docs json file when viewing the swagger GUI is not enough. The file gets generated on one server, while it is fetched from another that has not generated it yet.
By triggering the generation when fetching the docs file also, this is fixed.