### PR TITLE
OAS 3.0 uses servers specification instead of basePath

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -3,6 +3,7 @@
 namespace SwaggerLume;
 
 use Illuminate\Support\Facades\File;
+use OpenApi\Annotations\Server;
 
 class Generator
 {
@@ -28,7 +29,13 @@ class Generator
             }
 
             if (config('swagger-lume.paths.base') !== null) {
-                $swagger->basePath = config('swagger-lume.paths.base');
+                if (version_compare(config('swagger-lume.swagger_version'), '3.0', '>=')) {
+                    $swagger->servers = [
+                        new Server(['url' => config('swagger-lume.paths.base')]),
+                    ];
+                } else {
+                    $swagger->basePath = config('swagger-lume.paths.base');
+                }
             }
 
             $filename = $docDir.'/'.config('swagger-lume.paths.docs_json');


### PR DESCRIPTION
Hello,

Basically the same fix as in [L5-Swagger](https://github.com/DarkaOnLine/L5-Swagger/pull/146)
Check OpenAPI version for swagger-lume.paths.base.

Original issue :
Error during api docs generation : Unexpected field "basePath" for @OA\OpenApi()