### PR TITLE
fix(134): allow to use with zircode 4.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "require": {
     "php": ">=7.2 || ^8.0",
     "laravel/lumen-framework": "~6.0 || ~7.0 || ^8.0 || ^9.0 || ^10.0",
-    "zircote/swagger-php": "~2.0 || 3.*",
+    "zircote/swagger-php": "~2.0 || 3.* || 4.*",
     "swagger-api/swagger-ui": "^3.0 || ^4.0",
     "symfony/yaml": "^4.0 || ^5.0 || ^6.2"
   },


### PR DESCRIPTION
This change allows to use zircote/swagger-php 4.* with SwaggerLume.
Version 4.* is required if you want to use lumen 10.* with laravel-doctrine/orm (2.*) that does support that version of framework.

PS. Tests do fail. But i check them on master and they fail there to.